### PR TITLE
importing electronics no longer crashes on Windows

### DIFF
--- a/electronics/gateways/__init__.py
+++ b/electronics/gateways/__init__.py
@@ -1,3 +1,5 @@
+import platform
 from .buspirate import *
-from .linuxdevice import *
+if not platform.system() is "Windows":
+    from .linuxdevice import *
 from .mock import *


### PR DESCRIPTION
importing everything from `linuxdevice` automatically imports `smbus` which has the line `from fcntl import ioctl` and there is no `fcntl` on Windows, so a crash occurs. Here, linuxdevice isn't loaded on Windows systems.