### PR TITLE
added BusPirate.close()

### DIFF
--- a/electronics/gateways/buspirate.py
+++ b/electronics/gateways/buspirate.py
@@ -71,7 +71,11 @@ class BusPirate(object):
         self.device.timeout = 1
         self.device.flushInput()
         self.device.flushOutput()
-
+        
+    def close(self):
+        """disconnect from the hardware and make it available again."""
+        self.device.close()
+        
     def switch_mode(self, new_mode):
         """ Explicitly switch the Bus Pirate mode
 


### PR DESCRIPTION
Running a script in an IDE with an always-running interpreter (iPython), opening a gateway works the first time but fails later because it's never closed. Here, a function is added to disconnect from the hardware so a subsequent connection attempt does not fail.

```python
gw=BusPirate('COM3')
gw.close()
```